### PR TITLE
Stop enforcing medias to have their paths relative to the cwd

### DIFF
--- a/sloth/gui/labeltool.py
+++ b/sloth/gui/labeltool.py
@@ -440,8 +440,9 @@ class MainWindow(QMainWindow):
 
             fname = str(fname)
 
-            if os.path.isabs(fname):
-                fname = os.path.relpath(fname, str(path))
+            ## Not enforcing paths relative to the current working directory anymore
+            # if os.path.isabs(fname):
+            #     fname = os.path.relpath(fname, str(path))
 
             for pattern in image_types:
                 if fnmatch.fnmatch(fname, pattern):


### PR DESCRIPTION
@csaftoiu just commenting the path conversion.